### PR TITLE
new incoming type `float`, old was `int` , in result was rough jumpin…

### DIFF
--- a/gltf/src/net/mgsx/gltf/scene3d/scene/SceneManager.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/scene/SceneManager.java
@@ -265,7 +265,7 @@ public class SceneManager implements Disposable {
 		return renderableProviders;
 	}
 
-	public void updateViewport(int width, int height) {
+	public void updateViewport(float width, float height) {
 		if(camera != null){
 			camera.viewportWidth = width;
 			camera.viewportHeight = height;


### PR DESCRIPTION
…g in sizes after updateViewport.
Cosmetic fix, which prevent rough size jumping on screen when updateViewport executed
old rough code result, using `int` incoming.

https://user-images.githubusercontent.com/39751647/117253862-603a9200-ae50-11eb-8359-5c53d207db43.mp4

new smooth code result, using `float` incoming

https://user-images.githubusercontent.com/39751647/117253945-806a5100-ae50-11eb-8ac8-91f4e2215bde.mp4

