### PR TITLE
Improved color space conversion options (sRGB/Gamma correction)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 * Mesh without normal is rendered as unlit.
 * Shadows no longer impacts other directional lights.
 * Fix light contribution when using shadows. Directional light was slightly dimmed for no reason.
+* Gamma correction can be enabled/disabled for PBRShaderProvider.
+* Added SkyBox color space conversion options.
 
 ### 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 * Mesh without normal is rendered as unlit.
 * Shadows no longer impacts other directional lights.
 * Fix light contribution when using shadows. Directional light was slightly dimmed for no reason.
-* Gamma correction can be enabled/disabled for PBRShaderProvider.
+* Manual gamma correction is now configurable for PBRShaderProvider.
 * Added SkyBox color space conversion options.
 
 ### 1.0.0

--- a/demo/core/src/net/mgsx/gltf/demo/GLTFDemo.java
+++ b/demo/core/src/net/mgsx/gltf/demo/GLTFDemo.java
@@ -666,7 +666,7 @@ public class GLTFDemo extends ApplicationAdapter
 			{
 				PBRShaderConfig config = PBRShaderProvider.createDefaultConfig();
 				config.manualSRGB = ui.shaderSRGB.getSelected();
-				config.gammaCorrection = ui.shaderGammaCorrection.isOn();
+				config.manualGammaCorrection = ui.shaderGammaCorrection.isOn();
 				config.numBones = maxBones;
 				config.numDirectionalLights = info.dirLights;
 				config.numPointLights = info.pointLights;
@@ -679,7 +679,7 @@ public class GLTFDemo extends ApplicationAdapter
 				config.vertexShader = Gdx.files.classpath("net/mgsx/gltf/demo/shaders/gltf-ceil-shading.vs.glsl").readString();
 				config.fragmentShader = Gdx.files.classpath("net/mgsx/gltf/demo/shaders/gltf-ceil-shading.fs.glsl").readString();
 				config.manualSRGB = ui.shaderSRGB.getSelected();
-				config.gammaCorrection = ui.shaderGammaCorrection.isOn();
+				config.manualGammaCorrection = ui.shaderGammaCorrection.isOn();
 				config.numBones = maxBones;
 				config.numDirectionalLights = info.dirLights;
 				config.numPointLights = info.pointLights;

--- a/demo/core/src/net/mgsx/gltf/demo/GLTFDemo.java
+++ b/demo/core/src/net/mgsx/gltf/demo/GLTFDemo.java
@@ -130,6 +130,7 @@ public class GLTFDemo extends ApplicationAdapter
 	private DirectionalLight defaultLight;
 	private boolean shadersValid;
 	private boolean outlineShaderValid;
+	private boolean skyboxValid = true;
 	
 	private FrameBuffer depthFbo;
 	
@@ -418,6 +419,17 @@ public class GLTFDemo extends ApplicationAdapter
 		};
 		
 		ui.shaderSRGB.addListener(shaderOptionListener);
+		ui.shaderGammaCorrection.addListener(shaderOptionListener);
+		
+		ChangeListener skyboxOptionListener = new ChangeListener() {
+			@Override
+			public void changed(ChangeEvent event, Actor actor) {
+				invalidateSkybox();
+			}
+		};
+		
+		ui.skyboxSRGB.addListener(skyboxOptionListener);
+		ui.skyboxGammaCorrection.addListener(skyboxOptionListener);
 		
 		ui.sceneSelector.addListener(new ChangeListener() {
 			@Override
@@ -579,7 +591,21 @@ public class GLTFDemo extends ApplicationAdapter
 	private void invalidateOutlineShaders() {
 		outlineShaderValid = false;
 	}
+	private void invalidateSkybox() {
+		skyboxValid = false;
+	}
 	
+	private void validateSkybox(){
+		if(!skyboxValid){
+			skyboxValid = true;
+			skybox.dispose();
+			skybox = new SceneSkybox(environmentCubemap, ui.skyboxSRGB.getSelected(), ui.skyboxGammaCorrection.isOn());
+			if(ui.skyBoxEnabled.isOn()){
+				sceneManager.setSkyBox(skybox);
+			}
+		}
+	}
+
 	private void validateShaders(){
 		if(rootModel != null){
 			if(!shadersValid){
@@ -640,6 +666,7 @@ public class GLTFDemo extends ApplicationAdapter
 			{
 				PBRShaderConfig config = PBRShaderProvider.createDefaultConfig();
 				config.manualSRGB = ui.shaderSRGB.getSelected();
+				config.gammaCorrection = ui.shaderGammaCorrection.isOn();
 				config.numBones = maxBones;
 				config.numDirectionalLights = info.dirLights;
 				config.numPointLights = info.pointLights;
@@ -652,6 +679,7 @@ public class GLTFDemo extends ApplicationAdapter
 				config.vertexShader = Gdx.files.classpath("net/mgsx/gltf/demo/shaders/gltf-ceil-shading.vs.glsl").readString();
 				config.fragmentShader = Gdx.files.classpath("net/mgsx/gltf/demo/shaders/gltf-ceil-shading.fs.glsl").readString();
 				config.manualSRGB = ui.shaderSRGB.getSelected();
+				config.gammaCorrection = ui.shaderGammaCorrection.isOn();
 				config.numBones = maxBones;
 				config.numDirectionalLights = info.dirLights;
 				config.numPointLights = info.pointLights;
@@ -837,6 +865,7 @@ public class GLTFDemo extends ApplicationAdapter
 		
 		// recreate shaders if needed
 		validateShaders();
+		validateSkybox();
 
 		sceneManager.update(delta);
 		

--- a/demo/core/src/net/mgsx/gltf/demo/ui/GLTFDemoUI.java
+++ b/demo/core/src/net/mgsx/gltf/demo/ui/GLTFDemoUI.java
@@ -73,6 +73,7 @@ public class GLTFDemoUI extends Table {
 	private Node selectedNode;
 	protected CollapsableUI shaderOptions;
 	public SelectBox<SRGB> shaderSRGB;
+	public BooleanUI shaderGammaCorrection;
 	private CollapsableUI lightOptions;
 	public SelectBox<SceneModel> sceneSelector;
 	public SelectBox<String> lightSelector;
@@ -83,6 +84,8 @@ public class GLTFDemoUI extends Table {
 	public TextButton btAllAnimations;
 	public BooleanUI fogEnabled;
 	public BooleanUI skyBoxEnabled;
+	public SelectBox<SRGB> skyboxSRGB;
+	public BooleanUI skyboxGammaCorrection;
 	public Vector4UI fogColor;
 	public Vector3UI fogEquation;
 
@@ -232,6 +235,9 @@ public class GLTFDemoUI extends Table {
 		shaderOptions.optTable.add(shaderSRGB = new SelectBox<SRGB>(skin)).row();
 		shaderSRGB.setItems(SRGB.values());
 		shaderSRGB.setSelected(SRGB.ACCURATE);
+		
+		shaderOptions.optTable.add("Gamma correction");
+		shaderOptions.optTable.add(shaderGammaCorrection = new BooleanUI(skin, true)).row();
 
 		// Fog
 		shaderOptions.optTable.add("Fog");
@@ -250,6 +256,14 @@ public class GLTFDemoUI extends Table {
 		shaderOptions.optTable.add("SkyBox Color");
 		shaderOptions.optTable.add(skyBoxColor = new Vector4UI(skin, new Color(Color.WHITE))).row();
 		
+		shaderOptions.optTable.add("Skybox SRGB");
+		shaderOptions.optTable.add(skyboxSRGB = new SelectBox<SRGB>(skin)).row();
+		skyboxSRGB.setItems(SRGB.values());
+		skyboxSRGB.setSelected(SRGB.NONE);
+		
+		shaderOptions.optTable.add("Skybox Gamma");
+		shaderOptions.optTable.add(skyboxGammaCorrection = new BooleanUI(skin, false)).row();
+
 		// Outlines
 		root.add();
 		root.add(outlineOptions = new CollapsableUI(skin, "Outline Options", false)).row();

--- a/gltf/src/net/mgsx/gltf/scene3d/scene/SceneSkybox.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/scene/SceneSkybox.java
@@ -21,9 +21,11 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.Pool;
 
+import net.mgsx.gltf.scene3d.shaders.PBRShaderConfig.SRGB;
+
 public class SceneSkybox implements RenderableProvider, Updatable, Disposable {
 
-	private DefaultShaderProvider shaderProvider;
+	private ShaderProvider shaderProvider;
 	private Model boxModel;
 	private Renderable box;
 	
@@ -34,23 +36,49 @@ public class SceneSkybox implements RenderableProvider, Updatable, Disposable {
 	public SceneSkybox(Cubemap cubemap){
 		this(cubemap, null);
 	}
-	
+
+	/**
+	 * Create a sky box with color space conversion settings.
+	 * @param cubemap
+	 * @param manualSRGB see {@link net.mgsx.gltf.scene3d.shaders.PBRShaderConfig#manualSRGB}
+	 * @param gammaCorrection see {@link net.mgsx.gltf.scene3d.shaders.PBRShaderConfig#gammaCorrection}
+	 */
+	public SceneSkybox(Cubemap cubemap, SRGB manualSRGB, boolean gammaCorrection){
+		createShaderProvider(manualSRGB, gammaCorrection);
+		createBox(cubemap, shaderProvider);
+	}
+
 	/**
 	 * Create a sky box with an optional custom shader.
 	 * @param cubemap
 	 * @param shaderProvider when null, a default shader provider is used. when not null, caller is responsible to dispose it.
 	 */
 	public SceneSkybox(Cubemap cubemap, ShaderProvider shaderProvider){
-		
-		// create shader provider if needed
 		if(shaderProvider == null){
-			Config shaderConfig = new Config();
-			String basePathName = "net/mgsx/gltf/shaders/skybox";
-			shaderConfig.vertexShader = Gdx.files.classpath(basePathName + ".vs.glsl").readString();
-			shaderConfig.fragmentShader = Gdx.files.classpath(basePathName + ".fs.glsl").readString();
-			shaderProvider = this.shaderProvider = new DefaultShaderProvider(shaderConfig);
+			shaderProvider = createShaderProvider(SRGB.NONE, false);
 		}
-		
+		createBox(cubemap, shaderProvider);
+	}
+	
+	private ShaderProvider createShaderProvider(SRGB manualSRGB, boolean gammaCorrection){
+		String prefix = "";
+		if(manualSRGB != SRGB.NONE){
+			prefix += "#define MANUAL_SRGB\n";
+			if(manualSRGB == SRGB.FAST){
+				prefix += "#define SRGB_FAST_APPROXIMATION\n";
+			}
+		}
+		if(gammaCorrection){
+			prefix += "#define GAMMA_CORRECTION\n";
+		}
+		Config shaderConfig = new Config();
+		String basePathName = "net/mgsx/gltf/shaders/skybox";
+		shaderConfig.vertexShader = Gdx.files.classpath(basePathName + ".vs.glsl").readString();
+		shaderConfig.fragmentShader = prefix + Gdx.files.classpath(basePathName + ".fs.glsl").readString();
+		return this.shaderProvider = new DefaultShaderProvider(shaderConfig);
+	}
+	
+	private void createBox(Cubemap cubemap, ShaderProvider shaderProvider){
 		// create box
 		float boxScale = (float)(1.0 / Math.sqrt(2.0));
 		boxModel = new ModelBuilder().createBox(boxScale, boxScale, boxScale, new Material(), VertexAttributes.Usage.Position);

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderConfig.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderConfig.java
@@ -5,7 +5,22 @@ import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
 public class PBRShaderConfig extends DefaultShader.Config
 {
 	public static enum SRGB{NONE,FAST,ACCURATE}
+	/**
+	 * Enable conversion of SRGB space textures into linear space in shader.
+	 * Should be {@link SRGB#NONE} if your textures are already in linear space
+	 * or automatically converted by OpenGL when using {@link com.badlogic.gdx.graphics.GL30#GL_SRGB} format.
+	 */
 	public SRGB manualSRGB = SRGB.ACCURATE;
+
+	/**
+	 * Enable/Disable gamma correction.
+	 * Since gamma correction should only be done once as a final step,
+	 * this should be disabled when you want to apply it later (eg. in case of post process lighting calculation).
+	 * It also should be disabled when drawing to SRGB framebuffers since gamma correction will
+	 * be automatically done by OpenGL.
+	 * Default is true.
+	 */
+	public boolean gammaCorrection = true;
 	
 	/** string to prepend to shaders (version), automatic if null */
 	public String glslVersion = null;

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderConfig.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderConfig.java
@@ -20,7 +20,16 @@ public class PBRShaderConfig extends DefaultShader.Config
 	 * be automatically done by OpenGL.
 	 * Default is true.
 	 */
-	public boolean gammaCorrection = true;
+	public boolean manualGammaCorrection = true;
+	
+	/** Default gamma factor that gives good results on most monitors. */
+	public static final float DEFAULT_GAMMA = 2.2f;
+	
+	/**
+	 * Gamma value used when {@link #manualGammaCorrection} is enabled.
+	 * Default is 2.2 which is a standard value that gives good results on most monitors
+	 */
+	public float gamma = DEFAULT_GAMMA;
 	
 	/** string to prepend to shaders (version), automatic if null */
 	public String glslVersion = null;

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderProvider.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderProvider.java
@@ -133,8 +133,8 @@ public class PBRShaderProvider extends DefaultShaderProvider
 				prefix += "#define SRGB_FAST_APPROXIMATION\n";
 			}
 		}
-		if(config.gammaCorrection){
-			prefix += "#define GAMMA_CORRECTION\n";
+		if(config.manualGammaCorrection){
+			prefix += "#define GAMMA_CORRECTION " + config.gamma + "\n";
 		}
 		return prefix;
 	}

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderProvider.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShaderProvider.java
@@ -133,6 +133,9 @@ public class PBRShaderProvider extends DefaultShaderProvider
 				prefix += "#define SRGB_FAST_APPROXIMATION\n";
 			}
 		}
+		if(config.gammaCorrection){
+			prefix += "#define GAMMA_CORRECTION\n";
+		}
 		return prefix;
 	}
 	
@@ -202,16 +205,16 @@ public class PBRShaderProvider extends DefaultShaderProvider
 					}
 				}
 				// TODO check GLSL extension 'OES_standard_derivatives' for WebGL
-				// TODO check GLSL extension 'EXT_SRGB' for WebGL
 				
 				if(renderable.environment.has(ColorAttribute.AmbientLight)){
 					prefix += "#define ambientLightFlag\n";
 				}
 			}
 			
-			// SRGB
-			prefix += createPrefixSRGB(renderable, config);
 		}
+		
+		// SRGB
+		prefix += createPrefixSRGB(renderable, config);
 		
 		
 		// multi UVs

--- a/gltf/src/net/mgsx/gltf/shaders/emissive-only.fs.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/emissive-only.fs.glsl
@@ -118,7 +118,7 @@ void main() {
     
     // final frag color
 #ifdef GAMMA_CORRECTION
-    out_FragColor.rgb = vec3(pow(color,vec3(1.0/2.2)));
+    out_FragColor.rgb = vec3(pow(color,vec3(1.0/GAMMA_CORRECTION)));
 #else
     out_FragColor.rgb = color;
 #endif

--- a/gltf/src/net/mgsx/gltf/shaders/emissive-only.fs.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/emissive-only.fs.glsl
@@ -117,7 +117,7 @@ void main() {
 #endif
     
     // final frag color
-#ifdef MANUAL_SRGB
+#ifdef GAMMA_CORRECTION
     out_FragColor.rgb = vec3(pow(color,vec3(1.0/2.2)));
 #else
     out_FragColor.rgb = color;

--- a/gltf/src/net/mgsx/gltf/shaders/gdx-pbr.fs.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/gdx-pbr.fs.glsl
@@ -388,7 +388,7 @@ void main() {
     vec3 color = baseColor.rgb;
 
     // final frag color
-#ifdef MANUAL_SRGB
+#ifdef GAMMA_CORRECTION
     out_FragColor = vec4(pow(color,vec3(1.0/2.2)), baseColor.a);
 #else
     out_FragColor = vec4(color, baseColor.a);
@@ -619,7 +619,7 @@ void main() {
 
     
     // final frag color
-#ifdef MANUAL_SRGB
+#ifdef GAMMA_CORRECTION
     out_FragColor = vec4(pow(color,vec3(1.0/2.2)), baseColor.a);
 #else
     out_FragColor = vec4(color, baseColor.a);

--- a/gltf/src/net/mgsx/gltf/shaders/gdx-pbr.fs.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/gdx-pbr.fs.glsl
@@ -389,7 +389,7 @@ void main() {
 
     // final frag color
 #ifdef GAMMA_CORRECTION
-    out_FragColor = vec4(pow(color,vec3(1.0/2.2)), baseColor.a);
+    out_FragColor = vec4(pow(color,vec3(1.0/GAMMA_CORRECTION)), baseColor.a);
 #else
     out_FragColor = vec4(color, baseColor.a);
 #endif
@@ -620,7 +620,7 @@ void main() {
     
     // final frag color
 #ifdef GAMMA_CORRECTION
-    out_FragColor = vec4(pow(color,vec3(1.0/2.2)), baseColor.a);
+    out_FragColor = vec4(pow(color,vec3(1.0/GAMMA_CORRECTION)), baseColor.a);
 #else
     out_FragColor = vec4(color, baseColor.a);
 #endif

--- a/gltf/src/net/mgsx/gltf/shaders/skybox.fs.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/skybox.fs.glsl
@@ -38,7 +38,7 @@ void main() {
 	color *= u_diffuseColor;
 #endif
 #ifdef GAMMA_CORRECTION
-	gl_FragColor = vec4(pow(color.rgb, vec3(1.0/2.2)), 1.0);
+	gl_FragColor = vec4(pow(color.rgb, vec3(1.0/GAMMA_CORRECTION)), 1.0);
 #else
 	gl_FragColor = vec4(color.rgb, 1.0);
 #endif

--- a/gltf/src/net/mgsx/gltf/shaders/skybox.fs.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/skybox.fs.glsl
@@ -17,10 +17,29 @@ uniform samplerCube u_environmentCubemap;
 uniform vec4 u_diffuseColor;
 #endif
 
+vec4 SRGBtoLINEAR(vec4 srgbIn)
+{
+    #ifdef MANUAL_SRGB
+    #ifdef SRGB_FAST_APPROXIMATION
+    vec3 linOut = pow(srgbIn.xyz,vec3(2.2));
+    #else //SRGB_FAST_APPROXIMATION
+    vec3 bLess = step(vec3(0.04045),srgbIn.xyz);
+    vec3 linOut = mix( srgbIn.xyz/vec3(12.92), pow((srgbIn.xyz+vec3(0.055))/vec3(1.055),vec3(2.4)), bLess );
+    #endif //SRGB_FAST_APPROXIMATION
+    return vec4(linOut,srgbIn.w);;
+    #else //MANUAL_SRGB
+    return srgbIn;
+    #endif //MANUAL_SRGB
+}
+
 void main() {
-	vec4 color = textureCube(u_environmentCubemap, v_position.xyz);
+	vec4 color = SRGBtoLINEAR(textureCube(u_environmentCubemap, v_position.xyz));
 #ifdef diffuseColorFlag
 	color *= u_diffuseColor;
 #endif
-    gl_FragColor = vec4(color.rgb, 1.0);
+#ifdef GAMMA_CORRECTION
+	gl_FragColor = vec4(pow(color.rgb, vec3(1.0/2.2)), 1.0);
+#else
+	gl_FragColor = vec4(color.rgb, 1.0);
+#endif
 }


### PR DESCRIPTION
When you want to do some post processing lighting calculation (deferred shading, bloom, etc...), you want to apply gamma correction as a last step.

Current PBR shaders always applying gamma correction when sRGB conversion is enabled (which is the default). Also, Skybox shader don't have any options for color space conversion.

This PR separate sRGB conversion and gamma correction option and also add them to skybox shader.

Depending on game specific setup (textures in linear space, automatic OpenGL conversions/corrections), this PR allows fine tuning. For instance, assuming all your texture are in sRGB color space and you want to perform bloom effect. You want to render the scene in linear space (enabling manualSRGB option) into a framebuffer. Then you can apply your bloom effect and finally apply gamma correction.

 