### PR TITLE
Fix DirectionalShadowLight color.

### DIFF
--- a/gltf/src/net/mgsx/gltf/scene3d/lights/DirectionalLightEx.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/lights/DirectionalLightEx.java
@@ -28,7 +28,35 @@ public class DirectionalLightEx extends DirectionalLight
 		updateColor();
 		return this;
 	}
-	
+
+	@Override
+	public DirectionalLightEx set(Color color, Vector3 direction) {
+		if (color != null) this.baseColor.set(color);
+		if (direction != null) this.direction.set(direction).nor();
+		return this;
+	}
+
+	@Override
+	public DirectionalLightEx set(float r, float g, float b, Vector3 direction) {
+		this.baseColor.set(r, g, b, 1f);
+		if (direction != null) this.direction.set(direction).nor();
+		return this;
+	}
+
+	@Override
+	public DirectionalLightEx set(Color color, float dirX, float dirY, float dirZ) {
+		if (color != null) this.baseColor.set(color);
+		this.direction.set(dirX, dirY, dirZ).nor();
+		return this;
+	}
+
+	@Override
+	public DirectionalLightEx set(float r, float g, float b, float dirX, float dirY, float dirZ) {
+		this.baseColor.set(r, g, b, 1f).clamp();
+		this.direction.set(dirX, dirY, dirZ).nor();
+		return this;
+	}
+
 	public void updateColor(){
 		this.color.r = baseColor.r * intensity;
 		this.color.g = baseColor.g * intensity;

--- a/gltf/src/net/mgsx/gltf/scene3d/lights/DirectionalShadowLight.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/lights/DirectionalShadowLight.java
@@ -2,6 +2,7 @@ package net.mgsx.gltf.scene3d.lights;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -119,6 +120,34 @@ public class DirectionalShadowLight extends DirectionalLightEx implements Shadow
 
 	public Camera getCamera () {
 		return cam;
+	}
+
+	@Override
+	public DirectionalShadowLight set(Color color, Vector3 direction) {
+		if (color != null) this.baseColor.set(color);
+		if (direction != null) this.direction.set(direction).nor();
+		return this;
+	}
+
+	@Override
+	public DirectionalShadowLight set(float r, float g, float b, Vector3 direction) {
+		this.baseColor.set(r, g, b, 1f);
+		if (direction != null) this.direction.set(direction).nor();
+		return this;
+	}
+
+	@Override
+	public DirectionalShadowLight set(Color color, float dirX, float dirY, float dirZ) {
+		if (color != null) this.baseColor.set(color);
+		this.direction.set(dirX, dirY, dirZ).nor();
+		return this;
+	}
+
+	@Override
+	public DirectionalShadowLight set(float r, float g, float b, float dirX, float dirY, float dirZ) {
+		this.baseColor.set(r, g, b, 1f).clamp();
+		this.direction.set(dirX, dirY, dirZ).nor();
+		return this;
 	}
 
 	@Override

--- a/gltf/src/net/mgsx/gltf/scene3d/lights/DirectionalShadowLight.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/lights/DirectionalShadowLight.java
@@ -2,7 +2,6 @@ package net.mgsx.gltf.scene3d.lights;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -120,34 +119,6 @@ public class DirectionalShadowLight extends DirectionalLightEx implements Shadow
 
 	public Camera getCamera () {
 		return cam;
-	}
-
-	@Override
-	public DirectionalShadowLight set(Color color, Vector3 direction) {
-		if (color != null) this.baseColor.set(color);
-		if (direction != null) this.direction.set(direction).nor();
-		return this;
-	}
-
-	@Override
-	public DirectionalShadowLight set(float r, float g, float b, Vector3 direction) {
-		this.baseColor.set(r, g, b, 1f);
-		if (direction != null) this.direction.set(direction).nor();
-		return this;
-	}
-
-	@Override
-	public DirectionalShadowLight set(Color color, float dirX, float dirY, float dirZ) {
-		if (color != null) this.baseColor.set(color);
-		this.direction.set(dirX, dirY, dirZ).nor();
-		return this;
-	}
-
-	@Override
-	public DirectionalShadowLight set(float r, float g, float b, float dirX, float dirY, float dirZ) {
-		this.baseColor.set(r, g, b, 1f).clamp();
-		this.direction.set(dirX, dirY, dirZ).nor();
-		return this;
 	}
 
 	@Override


### PR DESCRIPTION
Default implementation modifies `color` variable in `set(...)` methods and because of this light color was always white. I changed this behavior to modify `baseColor` variable instead.