### PR TITLE
mod: support for USHORT UBYTE bone weights (used from Unreal exporter)

### DIFF
--- a/gltf/src/net/mgsx/gltf/loaders/shared/data/DataResolver.java
+++ b/gltf/src/net/mgsx/gltf/loaders/shared/data/DataResolver.java
@@ -1,3 +1,4 @@
+
 package net.mgsx.gltf.loaders.shared.data;
 
 import java.nio.ByteBuffer;
@@ -11,16 +12,16 @@ import net.mgsx.gltf.data.data.GLTFBufferView;
 import net.mgsx.gltf.loaders.shared.GLTFTypes;
 
 public class DataResolver {
-	
+
 	private GLTF glModel;
 	private DataFileResolver dataFileResolver;
-	
+
 	public DataResolver(GLTF glModel, DataFileResolver dataFileResolver) {
 		super();
 		this.glModel = glModel;
 		this.dataFileResolver = dataFileResolver;
 	}
-	
+
 	public GLTFAccessor getAccessor(int accessorID) {
 		return glModel.accessors.get(accessorID);
 	}
@@ -28,34 +29,52 @@ public class DataResolver {
 	public float[] readBufferFloat(int accessorID) {
 		GLTFAccessor accessor = glModel.accessors.get(accessorID);
 		FloatBuffer floatBuffer = getBufferFloat(accessorID);
-		float [] data = new float[GLTFTypes.accessorSize(accessor) / 4];
+		float[] data = new float[GLTFTypes.accessorSize(accessor) / 4];
 		floatBuffer.get(data);
 		return data;
 	}
-	
+
 	public int[] readBufferUByte(int accessorID) {
 		GLTFAccessor accessor = glModel.accessors.get(accessorID);
 		GLTFBufferView bufferView = glModel.bufferViews.get(accessor.bufferView);
 		ByteBuffer bytes = dataFileResolver.getBuffer(bufferView.buffer);
 		bytes.position(bufferView.byteOffset + accessor.byteOffset);
-		int [] data = new int[GLTFTypes.accessorSize(accessor)];
-		for(int i=0 ; i<data.length ; i++){
+		int[] data = new int[GLTFTypes.accessorSize(accessor)];
+		for (int i = 0; i < data.length; i++) {
 			data[i] = bytes.get() & 0xFF;
 		}
 		return data;
 	}
-	
+
 	public int[] readBufferUShort(int accessorID) {
 		GLTFAccessor accessor = glModel.accessors.get(accessorID);
 		GLTFBufferView bufferView = glModel.bufferViews.get(accessor.bufferView);
 		ByteBuffer bytes = dataFileResolver.getBuffer(bufferView.buffer);
 		bytes.position(bufferView.byteOffset + accessor.byteOffset);
 		ShortBuffer shorts = bytes.asShortBuffer();
-		int [] data = new int[GLTFTypes.accessorSize(accessor)/2];
-		for(int i=0 ; i<data.length ; i++){
+		int[] data = new int[GLTFTypes.accessorSize(accessor) / 2];
+		for (int i = 0; i < data.length; i++) {
 			data[i] = shorts.get() & 0xFFFF;
 		}
 		return data;
+	}
+
+	public float[] readBufferUShortAsFloat(int accessorID) {
+		int[] intBuffer = readBufferUShort(accessorID);
+		float[] floatBuffer = new float[intBuffer.length];
+		for (int i = 0; i < intBuffer.length; i++) {
+			floatBuffer[i] = intBuffer[i] / 65535f;
+		}
+		return floatBuffer;
+	}
+
+	public float[] readBufferUByteAsFloat(int accessorID) {
+		int[] intBuffer = readBufferUByte(accessorID);
+		float[] floatBuffer = new float[intBuffer.length];
+		for (int i = 0; i < intBuffer.length; i++) {
+			floatBuffer[i] = intBuffer[i] / 255f;
+		}
+		return floatBuffer;
 	}
 
 	public FloatBuffer getBufferFloat(int accessorID) {

--- a/gltf/src/net/mgsx/gltf/loaders/shared/geometry/MeshLoader.java
+++ b/gltf/src/net/mgsx/gltf/loaders/shared/geometry/MeshLoader.java
@@ -36,69 +36,69 @@ import net.mgsx.gltf.scene3d.model.NodePlus;
 import net.mgsx.gltf.scene3d.model.WeightVector;
 
 public class MeshLoader {
-	
+
 	private ObjectMap<GLTFMesh, Array<NodePart>> meshMap = new ObjectMap<GLTFMesh, Array<NodePart>>();
 	private final Array<Mesh> meshes = new Array<Mesh>();
-	
+
 	public void load(Node node, GLTFMesh glMesh, DataResolver dataResolver, MaterialLoader materialLoader) 
 	{
 		((NodePlus)node).morphTargetNames = BlenderShapeKeys.parse(glMesh);
-		
+
 		Array<NodePart> parts = meshMap.get(glMesh);
-		if(parts == null){
+		if (parts == null) {
 			parts = new Array<NodePart>();
-			
-			for(GLTFPrimitive primitive : glMesh.primitives){
-				
+
+			for (GLTFPrimitive primitive : glMesh.primitives) {
+
 				final int glPrimitiveType = GLTFTypes.mapPrimitiveMode(primitive.mode);
-				
+
 				// material
 				Material material;
-				if(primitive.material != null){
+				if (primitive.material != null) {
 					material = materialLoader.get(primitive.material);
-				}else{
+				} else {
 					material = materialLoader.getDefaultMaterial();
 				}
-				
+
 				// vertices
 				Array<VertexAttribute> vertexAttributes = new Array<VertexAttribute>();
 				Array<GLTFAccessor> glAccessors = new Array<GLTFAccessor>();
-				
+
 				Array<int[]> bonesIndices = new Array<int[]>();
 				Array<float[]> bonesWeights = new Array<float[]>();
-				
+
 				boolean hasNormals = false;
 				boolean hasTangent = false;
-				
-				for(Entry<String, Integer> attribute : primitive.attributes){
+
+				for (Entry<String, Integer> attribute : primitive.attributes) {
 					String attributeName = attribute.key;
 					int accessorId = attribute.value;
 					GLTFAccessor accessor = dataResolver.getAccessor(accessorId);
 					boolean rawAttribute = true;
-					
-					if(attributeName.equals("POSITION")){
+
+					if (attributeName.equals("POSITION")) {
 						if(!(GLTFTypes.TYPE_VEC3.equals(accessor.type) && accessor.componentType == GLTFTypes.C_FLOAT)) throw new GLTFIllegalException("illegal position attribute format");
 						vertexAttributes.add(VertexAttribute.Position());
-					}else if(attributeName.equals("NORMAL")){
+					} else if (attributeName.equals("NORMAL")) {
 						if(!(GLTFTypes.TYPE_VEC3.equals(accessor.type) && accessor.componentType == GLTFTypes.C_FLOAT)) throw new GLTFIllegalException("illegal normal attribute format");
 						vertexAttributes.add(VertexAttribute.Normal());
 						hasNormals = true;
-					}else if(attributeName.equals("TANGENT")){
+					} else if (attributeName.equals("TANGENT")) {
 						if(!(GLTFTypes.TYPE_VEC4.equals(accessor.type) && accessor.componentType == GLTFTypes.C_FLOAT)) throw new GLTFIllegalException("illegal tangent attribute format");
 						vertexAttributes.add(new VertexAttribute(Usage.Tangent, 4, ShaderProgram.TANGENT_ATTRIBUTE));
 						hasTangent = true;
-					}else if(attributeName.startsWith("TEXCOORD_")){
+					} else if (attributeName.startsWith("TEXCOORD_")) {
 						if(!GLTFTypes.TYPE_VEC2.equals(accessor.type)) throw new GLTFIllegalException("illegal texture coordinate attribute type : " + accessor.type);
 						if(accessor.componentType == GLTFTypes.C_UBYTE) throw new GLTFUnsupportedException("unsigned byte texture coordinate attribute not supported");
 						if(accessor.componentType == GLTFTypes.C_USHORT) throw new GLTFUnsupportedException("unsigned short texture coordinate attribute not supported");
 						if(accessor.componentType != GLTFTypes.C_FLOAT) throw new GLTFIllegalException("illegal texture coordinate component type : " + accessor.componentType);
 						int unit = parseAttributeUnit(attributeName);
 						vertexAttributes.add(VertexAttribute.TexCoords(unit));
-					}else if(attributeName.startsWith("COLOR_")){
+					} else if (attributeName.startsWith("COLOR_")) {
 						int unit = parseAttributeUnit(attributeName);
 						String alias = unit > 0 ? ShaderProgram.COLOR_ATTRIBUTE + unit : ShaderProgram.COLOR_ATTRIBUTE;
-						if(GLTFTypes.TYPE_VEC4.equals(accessor.type)){
-							if(GLTFTypes.C_FLOAT == accessor.componentType){
+						if (GLTFTypes.TYPE_VEC4.equals(accessor.type)) {
+							if (GLTFTypes.C_FLOAT == accessor.componentType) {
 								vertexAttributes.add(new VertexAttribute(Usage.ColorUnpacked, 4, GL20.GL_FLOAT, false, alias));
 							}
 							else if(GLTFTypes.C_USHORT == accessor.componentType){
@@ -106,12 +106,12 @@ public class MeshLoader {
 							}
 							else if(GLTFTypes.C_UBYTE == accessor.componentType){
 								vertexAttributes.add(new VertexAttribute(Usage.ColorUnpacked, 4, GL20.GL_UNSIGNED_BYTE, true, alias));
-							}else{
+							} else {
 								throw new GLTFIllegalException("illegal color attribute component type: " + accessor.type);
 							}
 						}
 						else if(GLTFTypes.TYPE_VEC3.equals(accessor.type)){
-							if(GLTFTypes.C_FLOAT == accessor.componentType){
+							if (GLTFTypes.C_FLOAT == accessor.componentType) {
 								vertexAttributes.add(new VertexAttribute(Usage.ColorUnpacked, 3, GL20.GL_FLOAT, false, alias));
 							}
 							else if(GLTFTypes.C_USHORT == accessor.componentType){
@@ -119,249 +119,248 @@ public class MeshLoader {
 							}
 							else if(GLTFTypes.C_UBYTE == accessor.componentType){
 								throw new GLTFUnsupportedException("RGB unsigned byte color attribute not supported");
-							}else{
+							} else {
 								throw new GLTFIllegalException("illegal color attribute component type: " + accessor.type);
 							}
 						}
 						else{
 							throw new GLTFIllegalException("illegal color attribute type: " + accessor.type);
 						}
-							
-					}else if(attributeName.startsWith("WEIGHTS_")){
+
+					} else if (attributeName.startsWith("WEIGHTS_")) {
 						rawAttribute = false;
-						
-						if(!GLTFTypes.TYPE_VEC4.equals(accessor.type)){
+
+						if (!GLTFTypes.TYPE_VEC4.equals(accessor.type)) {
 							throw new GLTFIllegalException("illegal weight attribute type: " + accessor.type);
 						}
-						
-						int unit = parseAttributeUnit(attributeName);
-						if(unit >= bonesWeights.size) bonesWeights.setSize(unit+1);
 
-						if(accessor.componentType == GLTFTypes.C_FLOAT){
+						int unit = parseAttributeUnit(attributeName);
+						if (unit >= bonesWeights.size) bonesWeights.setSize(unit + 1);
+
+						if (accessor.componentType == GLTFTypes.C_FLOAT) {
 							bonesWeights.set(unit, dataResolver.readBufferFloat(accessorId));
-						}else if(accessor.componentType == GLTFTypes.C_USHORT){ 
-							throw new GLTFUnsupportedException("unsigned short weight attribute not supported");
-						}else if(accessor.componentType == GLTFTypes.C_UBYTE){ 
-							throw new GLTFUnsupportedException("unsigned byte weight attribute not supported");
-						}else{
+						} else if (accessor.componentType == GLTFTypes.C_USHORT) {
+							bonesWeights.set(unit, dataResolver.readBufferUShortAsFloat(accessorId));
+						} else if (accessor.componentType == GLTFTypes.C_UBYTE) {
+							bonesWeights.set(unit, dataResolver.readBufferUByteAsFloat(accessorId));
+						} else {
 							throw new GLTFIllegalException("illegal weight attribute type: " + accessor.componentType);
 						}
-					}else if(attributeName.startsWith("JOINTS_")){
+					} else if (attributeName.startsWith("JOINTS_")) {
 						rawAttribute = false;
-						
-						if(!GLTFTypes.TYPE_VEC4.equals(accessor.type)){
+
+						if (!GLTFTypes.TYPE_VEC4.equals(accessor.type)) {
 							throw new GLTFIllegalException("illegal joints attribute type: " + accessor.type);
 						}
-						
+
 						int unit = parseAttributeUnit(attributeName);
-						if(unit >= bonesIndices.size) bonesIndices.setSize(unit+1);
-						
-						if(accessor.componentType == GLTFTypes.C_UBYTE){ // unsigned byte
+						if (unit >= bonesIndices.size) bonesIndices.setSize(unit + 1);
+
+						if (accessor.componentType == GLTFTypes.C_UBYTE) { // unsigned byte
 							bonesIndices.set(unit, dataResolver.readBufferUByte(accessorId));
-						}else if(accessor.componentType == GLTFTypes.C_USHORT){ // unsigned short
+						} else if (accessor.componentType == GLTFTypes.C_USHORT) { // unsigned short
 							bonesIndices.set(unit, dataResolver.readBufferUShort(accessorId));
-						}else{
+						} else {
 							throw new GLTFIllegalException("illegal type for joints: " + accessor.componentType);
 						}
 					}
 					else if(attributeName.startsWith("_")){
 						Gdx.app.error("GLTF", "skip unsupported custom attribute: " + attributeName);
-					}else{
+					} else {
 						throw new GLTFIllegalException("illegal attribute type " + attributeName);
 					}
-					
-					if(rawAttribute){
+
+					if (rawAttribute) {
 						glAccessors.add(accessor);
 					}
 				}
-				
+
 				// morph targets
-				if(primitive.targets != null){
+				if (primitive.targets != null) {
 					int morphTargetCount = primitive.targets.size;
 					((NodePlus)node).weights = new WeightVector(morphTargetCount);
-					
-					for(int t=0 ; t<primitive.targets.size ; t++){
+
+					for (int t = 0; t < primitive.targets.size; t++) {
 						int unit = t;
-						for(Entry<String, Integer> attribute : primitive.targets.get(t)){
+						for (Entry<String, Integer> attribute : primitive.targets.get(t)) {
 							String attributeName = attribute.key;
 							int accessorId = attribute.value.intValue();
 							GLTFAccessor accessor = dataResolver.getAccessor(accessorId);
 							glAccessors.add(accessor);
-							
-							if(attributeName.equals("POSITION")){
+
+							if (attributeName.equals("POSITION")) {
 								if(!(GLTFTypes.TYPE_VEC3.equals(accessor.type) && accessor.componentType == GLTFTypes.C_FLOAT)) throw new GLTFIllegalException("illegal morph target position attribute format");
 								vertexAttributes.add(new VertexAttribute(PBRVertexAttributes.Usage.PositionTarget, 3, ShaderProgram.POSITION_ATTRIBUTE+unit, unit));
-							}else if(attributeName.equals("NORMAL")){
+							} else if (attributeName.equals("NORMAL")) {
 								if(!(GLTFTypes.TYPE_VEC3.equals(accessor.type) && accessor.componentType == GLTFTypes.C_FLOAT)) throw new GLTFIllegalException("illegal morph target normal attribute format");
 								vertexAttributes.add(new VertexAttribute(PBRVertexAttributes.Usage.NormalTarget, 3, ShaderProgram.NORMAL_ATTRIBUTE + unit, unit));
-							}else if(attributeName.equals("TANGENT")){
+							} else if (attributeName.equals("TANGENT")) {
 								if(!(GLTFTypes.TYPE_VEC3.equals(accessor.type) && accessor.componentType == GLTFTypes.C_FLOAT)) throw new GLTFIllegalException("illegal morph target tangent attribute format");
 								vertexAttributes.add(new VertexAttribute(PBRVertexAttributes.Usage.TangentTarget, 3, ShaderProgram.TANGENT_ATTRIBUTE + unit, unit));
-							}else{
+							} else {
 								throw new GLTFIllegalException("illegal morph target attribute type " + attributeName);
 							}
 						}
 					}
-					
+
 				}
-				
+
 				int bSize = bonesIndices.size * 4;
 
 				Array<VertexAttribute> bonesAttributes = new Array<VertexAttribute>();
-				for(int b=0 ; b<bSize ; b++){
+				for (int b = 0; b < bSize; b++) {
 					VertexAttribute boneAttribute = VertexAttribute.BoneWeight(b);
 					vertexAttributes.add(boneAttribute);
 					bonesAttributes.add(boneAttribute);
 				}
-				
+
 				// add missing vertex attributes (normals and tangent)
 				boolean computeNormals = false;
 				boolean computeTangents = false;
 				VertexAttribute normalMapUVs = null;
-				if(glPrimitiveType == GL20.GL_TRIANGLES){
-					if(!hasNormals){
+				if (glPrimitiveType == GL20.GL_TRIANGLES) {
+					if (!hasNormals) {
 						vertexAttributes.add(VertexAttribute.Normal());
 						glAccessors.add(null);
 						computeNormals = true;
 					}
-					if(!hasTangent){
+					if (!hasTangent) {
 						// tangent is only needed when normal map is used
 						PBRTextureAttribute normalMap = material.get(PBRTextureAttribute.class, PBRTextureAttribute.NormalTexture);
-						if(normalMap != null){
+						if (normalMap != null) {
 							vertexAttributes.add(new VertexAttribute(Usage.Tangent, 4, ShaderProgram.TANGENT_ATTRIBUTE));
 							glAccessors.add(null);
 							computeTangents = true;
-							for(VertexAttribute attribute : vertexAttributes){
-								if(attribute.usage == Usage.TextureCoordinates && attribute.unit == normalMap.uvIndex){
+							for (VertexAttribute attribute : vertexAttributes) {
+								if (attribute.usage == Usage.TextureCoordinates && attribute.unit == normalMap.uvIndex) {
 									normalMapUVs = attribute;
 								}
 							}
-							if(normalMapUVs == null) throw new GLTFIllegalException("UVs not found for normal map");
+							if (normalMapUVs == null) throw new GLTFIllegalException("UVs not found for normal map");
 						}
 					}
 				}
-				
+
 				VertexAttributes attributesGroup = new VertexAttributes((VertexAttribute[])vertexAttributes.toArray(VertexAttribute.class));
-				
-				int vertexFloats = attributesGroup.vertexSize/4;
-				
+
+				int vertexFloats = attributesGroup.vertexSize / 4;
+
 				int maxVertices = glAccessors.first().count;
 
-				float [] vertices = new float [maxVertices * vertexFloats];
-				
-				for(int b=0 ; b<bSize ; b++){
+				float[] vertices = new float[maxVertices * vertexFloats];
+
+				for (int b = 0; b < bSize; b++) {
 					VertexAttribute boneAttribute = bonesAttributes.get(b);
-					for(int i=0 ; i<maxVertices ; i++){
-						vertices[i * vertexFloats + boneAttribute.offset/4] = bonesIndices.get(b/4)[i * 4 + b%4];
-						vertices[i * vertexFloats + boneAttribute.offset/4+1] = bonesWeights.get(b/4)[i * 4 + b%4];
+					for (int i = 0; i < maxVertices; i++) {
+						vertices[i * vertexFloats + boneAttribute.offset / 4] = bonesIndices.get(b / 4)[i * 4 + b % 4];
+						vertices[i * vertexFloats + boneAttribute.offset / 4 + 1] = bonesWeights.get(b / 4)[i * 4 + b % 4];
 					}
 				}
-				
-				for(int i=0 ; i<glAccessors.size ; i++){
+
+				for (int i = 0; i < glAccessors.size; i++) {
 					GLTFAccessor glAccessor = glAccessors.get(i);
 					VertexAttribute attribute = vertexAttributes.get(i);
-					
-					
-					if(glAccessor == null) continue;
-					
-					if(glAccessor.bufferView == null){
+
+					if (glAccessor == null) continue;
+
+					if (glAccessor.bufferView == null) {
 						throw new GLTFIllegalException("bufferView is null (mesh compression ?)");
 					}
-					
+
 					GLTFBufferView glBufferView = dataResolver.getBufferView(glAccessor.bufferView);
-					
+
 					// not used for now : used for direct mesh ....
-					if(glBufferView.target != null){
-						if(glBufferView.target == 34963){ // ELEMENT_ARRAY_BUFFER
-						}else if(glBufferView.target == 34962){ // ARRAY_BUFFER
-						}else{
+					if (glBufferView.target != null) {
+						if (glBufferView.target == 34963) { // ELEMENT_ARRAY_BUFFER
+						} else if (glBufferView.target == 34962) { // ARRAY_BUFFER
+						} else {
 							throw new GLTFRuntimeException("bufferView target unknown : " + glBufferView.target);
 						}
 					}
-					
+
 					FloatBuffer floatBuffer = dataResolver.getBufferFloat(glAccessor);
-					
+
 					int attributeFloats = GLTFTypes.accessorStrideSize(glAccessor) / 4;
 
-					// buffer can be interleaved, so vertex stride may be different than vertex size 
+					// buffer can be interleaved, so vertex stride may be different than vertex size
 					int floatStride = glBufferView.byteStride == null ? attributeFloats : glBufferView.byteStride / 4;
-					
-					for(int j=0 ; j<glAccessor.count ; j++){
-						
+
+					for (int j = 0; j < glAccessor.count; j++) {
+
 						floatBuffer.position(j * floatStride);
-						
-						int vIndex = j * vertexFloats + attribute.offset/4;
-						
+
+						int vIndex = j * vertexFloats + attribute.offset / 4;
+
 						floatBuffer.get(vertices, vIndex, attributeFloats);
 					}
 				}
-				
+
 				// indices
-				if(primitive.indices != null){
-					
+				if (primitive.indices != null) {
+
 					GLTFAccessor indicesAccessor = dataResolver.getAccessor(primitive.indices);
-					
-					if(!indicesAccessor.type.equals(GLTFTypes.TYPE_SCALAR)){
+
+					if (!indicesAccessor.type.equals(GLTFTypes.TYPE_SCALAR)) {
 						throw new GLTFIllegalException("indices accessor must be SCALAR but was " + indicesAccessor.type);
 					}
-						
+
 					int maxIndices = indicesAccessor.count;
-					
-					switch(indicesAccessor.componentType){
+
+					switch (indicesAccessor.componentType) {
 					case GLTFTypes.C_UINT:
 						{
-							Gdx.app.error("GLTF", "integer indices partially supported, mesh will be split");
-							Gdx.app.error("GLTF", "splitting mesh: " + maxVertices + " vertices, " + maxIndices + " indices.");
+						Gdx.app.error("GLTF", "integer indices partially supported, mesh will be split");
+						Gdx.app.error("GLTF", "splitting mesh: " + maxVertices + " vertices, " + maxIndices + " indices.");
 
-							int verticesPerPrimitive;
-							if(glPrimitiveType == GL20.GL_TRIANGLES){
-								verticesPerPrimitive = 3;
-							}else if(glPrimitiveType == GL20.GL_LINES){
-								verticesPerPrimitive = 2;
-							}else{
-								throw new GLTFUnsupportedException("integer indices only supported for triangles or lines");
-							}
-							
-							int [] indices = new int[maxIndices];
-							dataResolver.getBufferInt(indicesAccessor).get(indices);
-							
-							Array<float[]> splitVertices = new Array<float[]>();
-							Array<short[]> splitIndices = new Array<short[]>();
-							
-							MeshSpliter.split(splitVertices, splitIndices, vertices, attributesGroup, indices, verticesPerPrimitive);
-							
-							int stride = attributesGroup.vertexSize / 4;
-							int groups = splitIndices.size;
-							int totalVertices = 0;
-							int totalIndices = 0;
-							for(int i=0 ; i<groups ; i++){
-								float[] groupVertices = splitVertices.get(i);
-								short[] groupIndices = splitIndices.get(i);
-								int groupVertexCount = groupVertices.length / stride;
-								
-								totalVertices += groupVertexCount;
-								totalIndices += groupIndices.length;
-								
-								Gdx.app.error("GLTF", "generate mesh: " + groupVertexCount + " vertices, " + groupIndices.length + " indices.");
-								
-								generateParts(node, parts, material, glMesh.name, groupVertices, groupVertexCount, groupIndices, attributesGroup, glPrimitiveType, computeNormals, computeTangents, normalMapUVs);
-							}
-							Gdx.app.error("GLTF", "mesh split: " + parts.size + " meshes generated: " + totalVertices + " vertices, " + totalIndices + " indices.");
+						int verticesPerPrimitive;
+						if (glPrimitiveType == GL20.GL_TRIANGLES) {
+							verticesPerPrimitive = 3;
+						} else if (glPrimitiveType == GL20.GL_LINES) {
+							verticesPerPrimitive = 2;
+						} else {
+							throw new GLTFUnsupportedException("integer indices only supported for triangles or lines");
 						}
+
+						int[] indices = new int[maxIndices];
+						dataResolver.getBufferInt(indicesAccessor).get(indices);
+
+						Array<float[]> splitVertices = new Array<float[]>();
+						Array<short[]> splitIndices = new Array<short[]>();
+
+						MeshSpliter.split(splitVertices, splitIndices, vertices, attributesGroup, indices, verticesPerPrimitive);
+
+						int stride = attributesGroup.vertexSize / 4;
+						int groups = splitIndices.size;
+						int totalVertices = 0;
+						int totalIndices = 0;
+						for (int i = 0; i < groups; i++) {
+							float[] groupVertices = splitVertices.get(i);
+							short[] groupIndices = splitIndices.get(i);
+							int groupVertexCount = groupVertices.length / stride;
+
+							totalVertices += groupVertexCount;
+							totalIndices += groupIndices.length;
+
+								Gdx.app.error("GLTF", "generate mesh: " + groupVertexCount + " vertices, " + groupIndices.length + " indices.");
+
+								generateParts(node, parts, material, glMesh.name, groupVertices, groupVertexCount, groupIndices, attributesGroup, glPrimitiveType, computeNormals, computeTangents, normalMapUVs);
+						}
+							Gdx.app.error("GLTF", "mesh split: " + parts.size + " meshes generated: " + totalVertices + " vertices, " + totalIndices + " indices.");
+					}
 						break;
 					case GLTFTypes.C_USHORT:
 					case GLTFTypes.C_SHORT:
 					{
-						short [] indices = new short[maxIndices];
+						short[] indices = new short[maxIndices];
 						dataResolver.getBufferShort(indicesAccessor).get(indices);
 						generateParts(node, parts, material, glMesh.name, vertices, maxVertices, indices, attributesGroup, glPrimitiveType, computeNormals, computeTangents, normalMapUVs);
 						break;
 					}
 					case GLTFTypes.C_UBYTE:
 					{
-						short [] indices = new short[maxIndices];
+						short[] indices = new short[maxIndices];
 						ByteBuffer byteBuffer = dataResolver.getBufferByte(indicesAccessor);
-						for(int i=0 ; i<maxIndices ; i++){
+						for (int i = 0; i < maxIndices; i++) {
 							indices[i] = (short)(byteBuffer.get() & 0xFF);
 						}
 						generateParts(node, parts, material, glMesh.name, vertices, maxVertices, indices, attributesGroup, glPrimitiveType, computeNormals, computeTangents, normalMapUVs);
@@ -370,7 +369,7 @@ public class MeshLoader {
 					default:
 						throw new GLTFIllegalException("illegal componentType " + indicesAccessor.componentType);
 					}
-				}else{
+				} else {
 					// non indexed mesh
 					generateParts(node, parts, material, glMesh.name, vertices, maxVertices, null, attributesGroup, glPrimitiveType, computeNormals, computeTangents, normalMapUVs);
 				}
@@ -382,39 +381,38 @@ public class MeshLoader {
 
 	private void generateParts(Node node, Array<NodePart> parts, Material material, String id, float[] vertices, int vertexCount, short[] indices, VertexAttributes attributesGroup, int glPrimitiveType, boolean computeNormals, boolean computeTangents, VertexAttribute normalMapUVs) {
 
-		if(computeNormals || computeTangents){
+		if (computeNormals || computeTangents) {
 			if(computeNormals && computeTangents) Gdx.app.log("GLTF", "compute normals and tangents for primitive " + id);
 			else if(computeTangents) Gdx.app.log("GLTF", "compute tangents for primitive " + id);
 			else Gdx.app.log("GLTF", "compute normals for primitive " + id);
 			MeshTangentSpaceGenerator.computeTangentSpace(vertices, indices, attributesGroup, computeNormals, computeTangents, normalMapUVs);
 		}
-		
+
 		Mesh mesh = new Mesh(true, vertexCount, indices == null ? 0 : indices.length, attributesGroup);
 		meshes.add(mesh);
 		mesh.setVertices(vertices);
-		
-		if(indices != null){
+
+		if (indices != null) {
 			mesh.setIndices(indices);
 		}
-		
+
 		int len = indices == null ? vertexCount : indices.length;
-		
+
 		MeshPart meshPart = new MeshPart(id, mesh, 0, len, glPrimitiveType);
-		
-		
+
 		NodePartPlus nodePart = new NodePartPlus();
 		nodePart.morphTargets = ((NodePlus)node).weights;
 		nodePart.meshPart = meshPart;
 		nodePart.material = material;
 		parts.add(nodePart);
-		
+
 	}
 
 	private int parseAttributeUnit(String attributeName) {
 		int lastUnderscoreIndex = attributeName.lastIndexOf('_');
-		try{
-			return Integer.parseInt(attributeName.substring(lastUnderscoreIndex+1));
-		}catch(NumberFormatException e){
+		try {
+			return Integer.parseInt(attributeName.substring(lastUnderscoreIndex + 1));
+		} catch (NumberFormatException e) {
 			throw new GLTFIllegalException("illegal attribute name " + attributeName);
 		}
 	}


### PR DESCRIPTION
The Unreal glTF exporter may use USHORT/UBYTE bone weights. This patch adds support for such formats