### PR TITLE
[GLTFExample] Fixed resouces file paths

### DIFF
--- a/demo/core/src/net/mgsx/gltf/examples/GLTFExample.java
+++ b/demo/core/src/net/mgsx/gltf/examples/GLTFExample.java
@@ -50,11 +50,11 @@ public class GLTFExample extends ApplicationAdapter
 		
 		// setup IBL (image based lighting)
 		environmentCubemap = EnvironmentUtil.createCubemap(new InternalFileHandleResolver(), 
-				"textures/environment/environment_", "_0.png", EnvironmentUtil.FACE_NAMES_NEG_POS);
+				"textures/environment/environment_", ".png", EnvironmentUtil.FACE_NAMES_NEG_POS);
 		diffuseCubemap = EnvironmentUtil.createCubemap(new InternalFileHandleResolver(), 
-				"textures/diffuse/diffuse_", "_0.jpg", EnvironmentUtil.FACE_NAMES_NEG_POS);
+				"textures/diffuse/diffuse_", ".png", EnvironmentUtil.FACE_NAMES_NEG_POS);
 		specularCubemap = EnvironmentUtil.createCubemap(new InternalFileHandleResolver(), 
-				"textures/specular/specular_", "_", ".jpg", 10, EnvironmentUtil.FACE_NAMES_NEG_POS);
+				"textures/specular/specular_", "_", ".png", 10, EnvironmentUtil.FACE_NAMES_NEG_POS);
 		brdfLUT = new Texture(Gdx.files.classpath("net/mgsx/gltf/shaders/brdfLUT.png"));
 		
 		sceneManager.setAmbientLight(1f);


### PR DESCRIPTION
The example `net.mgsx.gltf.demo.ExempleLauncher` is not running because of wrong resource file paths