### PR TITLE
GL memory leak in IBLComposer: radiance fbo and default BRDF texture are never released

### DIFF
--- a/ibl-composer/src/net/mgsx/gltf/ibl/model/EnvironmentBaker.java
+++ b/ibl-composer/src/net/mgsx/gltf/ibl/model/EnvironmentBaker.java
@@ -36,7 +36,7 @@ public class EnvironmentBaker implements Disposable {
 	public void dispose() {
 		rectToCubeShader.dispose();
 		rectToCubeRenderer.dispose();
-		fboEnv.dispose();
+		if(fboEnv != null) fboEnv.dispose();
 	}
 	
 	private static ShaderProgram loadShader(String name){

--- a/ibl-composer/src/net/mgsx/gltf/ibl/model/IBLComposer.java
+++ b/ibl-composer/src/net/mgsx/gltf/ibl/model/IBLComposer.java
@@ -63,6 +63,8 @@ public class IBLComposer implements Disposable {
 		if(pixmapRaw != null) pixmapRaw.dispose();
 		if(textureRaw != null) textureRaw.dispose();
 		if(irradianceMap != null) irradianceMap.dispose();
+		if(radianceMap != null) radianceMap.dispose();
+		if(builtinBRDF != null) builtinBRDF.dispose();
 		environmentBaker.dispose();
 		irradianceBaker.dispose();
 		radianceBaker.dispose();


### PR DESCRIPTION
The radiance fbo and default BRDF texture are never released when calling `IBLComposer.dispose()`. 
Here's the code to replicate: 

```
for (;;)
{
	try
	{
		IBLComposer c = new IBLComposer();
		c.loadHDR(new FileHandle(filename));

		c.getEnvMap(1024, 1f);
		c.getRadianceMap(1024);
		c.getIrradianceMap(1024);
		c.getDefaultBRDFMap();

		c.dispose();

		Thread.sleep(200);
	}
	catch (Exception e)
	{
		e.printStackTrace();
	}
}
```
In addition, this PR fixes a possible NPE when disposing EnvironmentBaker class.

--