### PR TITLE
Allow separate radiance map creation

### DIFF
--- a/ibl-composer/src/net/mgsx/gltf/ibl/model/IBLComposer.java
+++ b/ibl-composer/src/net/mgsx/gltf/ibl/model/IBLComposer.java
@@ -149,6 +149,21 @@ public class IBLComposer implements Disposable {
 		return radianceBaker.createPixmaps(cubemap, size);
 	}
 	
+	public Cubemap getSeparateRadianceMap(int size, float exposure){
+		getHDRTexture();
+		EnvironmentBaker environmentBaker = new EnvironmentBaker();
+		Cubemap cubemap = environmentBaker.getEnvMap(textureRaw, size, exposure);
+		if(radianceMap != null) radianceMap.dispose();
+		try{
+			radianceMap = radianceBaker.createRadiance(cubemap, size);
+		}catch(IllegalStateException e){
+			radianceMap = new Cubemap(1, 1, 1, Format.RGB888);
+			throw new FrameBufferError(e);
+		}
+		environmentBaker.dispose();
+		return radianceMap;	
+	}	
+	
 	public Cubemap getRadianceMap(int size){
 		Cubemap cubemap = environmentBaker.getLastMap(); // getEnvMap(size, exposure);
 		if(radianceMap != null) radianceMap.dispose();


### PR DESCRIPTION
Quick PR that allows the creation of separate radiance map differently sized from global environment map. 
This is useful when we want to use the main envmap for skybox and a small radiance cubemap.

--