### PR TITLE
Incorrect handling of iridescenceThickness sampler in PBR shader

### DIFF
--- a/gltf/src/net/mgsx/gltf/shaders/pbr/material.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/pbr/material.glsl
@@ -272,7 +272,7 @@ PBRSurfaceInfo getIridescenceInfo(PBRSurfaceInfo info){
 	info.iridescenceFactor *= texture2D(u_iridescenceSampler, v_iridescenceUV).r;
 #endif
 
-#ifdef iridescenceTextureFlag
+#ifdef iridescenceThicknessTextureFlag
 	float thicknessFactor = texture2D(u_iridescenceThicknessSampler, v_iridescenceThicknessUV).g;
 	info.iridescenceThickness = mix(u_iridescenceThicknessMin, u_iridescenceThicknessMax, thicknessFactor);
 #endif


### PR DESCRIPTION
Compilation error: 

```
com.badlogic.gdx.utils.GdxRuntimeException: Shader compilation failed:
Fragment shader:
0(569) : error C1503: undefined variable "u_iridescenceThicknessSampler"

	at net.mgsx.gltf.scene3d.shaders.PBRShaderProvider.checkShaderCompilation(PBRShaderProvider.java:522)
	at net.mgsx.gltf.scene3d.shaders.PBRShaderProvider.createShader(PBRShaderProvider.java:493)

```