### PR TITLE
Copy morphTargets when copying NodePartPlus

### DIFF
--- a/gltf/src/net/mgsx/gltf/scene3d/model/NodePartPlus.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/model/NodePartPlus.java
@@ -30,7 +30,7 @@ public class NodePartPlus extends NodePart{
 	protected NodePart set(NodePart other) {
 		super.set(other);
 		if(other instanceof NodePartPlus){
-			morphTargets = ((NodePartPlus) other).morphTargets;
+			morphTargets = ((NodePartPlus) other).morphTargets.cpy();
 		}
 		return this;
 	}


### PR DESCRIPTION
Thanks for this great project!

I noticed a problem when creating multiple Scenes from the same SceneModel. When I start an animation on one of them, it plays for all of the instances. 

```java
...

SceneModel model = sceneAsset.scene;
sceneManager = new SceneManager();
Scene scene1 = new Scene(model);
sceneManager.addScene(scene1);
Scene scene2 = new Scene(model);
sceneManager.addScene(scene2);

scene1.animationController.action("KeyAction", 1, 1f, listener, 0f);
// expectation: animation only plays on scene1
// actual result: animation plays on both scenes
```

After some digging I think I found the reason. It is because the `NodePartPlus.set` method does not copy the `morphTargets`, but uses the same instance as the other object. My workaround for now is this:

```java
Scene scene = new Scene(model);
for (Node node : scene.modelInstance.nodes) {
    for (NodePart part : node.parts) {
        if (part instanceof NodePartPlus) {
            ((NodePartPlus) part).morphTargets = ((NodePartPlus) part).morphTargets.cpy();
        }
    }
}
```