### PR TITLE
handling of CSM uniforms made compatible with WebGL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
 
     group = 'com.github.mgsx-dev.gdx-gltf'
-    version = '2.1.0.1'
+    version = '2.1.0'
     
     apply plugin: "eclipse"
 	apply plugin: "idea"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
 
     group = 'com.github.mgsx-dev.gdx-gltf'
-    version = '2.1.0'
+    version = '2.1.0.1'
     
     apply plugin: "eclipse"
 	apply plugin: "idea"

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
@@ -525,14 +525,12 @@ public class PBRShader extends DefaultShader
 	public int u_viewportInv;
 	public int u_clippingPlane;
 
-	private static final int MAX_CSM = 8;
-	
-	public int [] u_csmSamplers = new int[MAX_CSM];
+	public int [] u_csmSamplers;
 	public int u_csmPCFClip;
 	public int u_csmTransforms;
 
-	private float [] csmTransforms = new float[MAX_CSM * 16];
-	private float [] csmPCFClip = new float[MAX_CSM * 2];
+	private float [] csmTransforms;
+	private float [] csmPCFClip;
 
 	private static final Matrix3 textureTransform = new Matrix3();
 	
@@ -546,6 +544,10 @@ public class PBRShader extends DefaultShader
 		vertexColorLayers = computeVertexColorLayers(renderable);
 
 		cascadeCount = countShadowCascades(renderable);
+
+		u_csmSamplers = new int[cascadeCount];
+		csmTransforms = new float[cascadeCount * 16];
+		csmPCFClip = new float[cascadeCount * 2];
 		
 		// base color
 		u_BaseColorTexture = register(baseColorTextureUniform, baseColorTextureSetter);

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
@@ -831,8 +831,8 @@ public class PBRShader extends DefaultShader
 				csmPCFClip[i*2] = pcf;
 				csmPCFClip[i*2+1] = clip;
 			}
-			Gdx.gl.glUniformMatrix4fv(u_csmTransforms, lights.size, false, csmTransforms, 0);
-			Gdx.gl.glUniform2fv(u_csmPCFClip, lights.size, csmPCFClip, 0);
+			program.setUniformMatrix4fv(u_csmTransforms, csmTransforms, 0, lights.size);
+			program.setUniform2fv(u_csmPCFClip, csmPCFClip, 0, lights.size); 
 		}
 	}
 	

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
@@ -819,7 +819,7 @@ public class PBRShader extends DefaultShader
 		}
 		
 		CascadeShadowMapAttribute csmAttrib = attributes.get(CascadeShadowMapAttribute.class, CascadeShadowMapAttribute.Type);
-		if(csmAttrib != null && u_csmSamplers[0] >= 0){
+		if(csmAttrib != null && u_csmSamplers.length > 0 && u_csmSamplers[0] >= 0){
 			Array<DirectionalShadowLight> lights = csmAttrib.cascadeShadowMap.lights;
 			for(int i=0 ; i<lights.size ; i++){
 				DirectionalShadowLight light = lights.get(i);

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
@@ -831,8 +831,8 @@ public class PBRShader extends DefaultShader
 				csmPCFClip[i*2] = pcf;
 				csmPCFClip[i*2+1] = clip;
 			}
-			program.setUniformMatrix4fv(u_csmTransforms, csmTransforms, 0, lights.size);
-			program.setUniform2fv(u_csmPCFClip, csmPCFClip, 0, lights.size); 
+			program.setUniformMatrix4fv(u_csmTransforms, csmTransforms, 0, csmTransforms.length);
+			program.setUniform2fv(u_csmPCFClip, csmPCFClip, 0, csmPCFClip.length); 
 		}
 	}
 	

--- a/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
+++ b/gltf/src/net/mgsx/gltf/scene3d/shaders/PBRShader.java
@@ -1,6 +1,5 @@
 package net.mgsx.gltf.scene3d.shaders;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
@@ -630,10 +629,11 @@ public class PBRShader extends DefaultShader
 	}
 
 	private int countShadowCascades(Renderable renderable ){
-		CascadeShadowMapAttribute csm = renderable.environment.get(CascadeShadowMapAttribute.class, CascadeShadowMapAttribute.Type);
-		if(csm == null)
-			return 0;
-		return csm.cascadeShadowMap.lights.size;
+		if(renderable.environment != null) {
+			CascadeShadowMapAttribute csm = renderable.environment.get(CascadeShadowMapAttribute.class, CascadeShadowMapAttribute.Type);
+			if(csm != null) return csm.cascadeShadowMap.lights.size;
+		}
+		return 0;
 	}
 
 	@Override

--- a/gltf/src/net/mgsx/gltf/shaders/pbr/shadows.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/pbr/shadows.glsl
@@ -6,7 +6,7 @@ varying vec3 v_shadowMapUv;
 
 #ifdef numCSM
 
-// arrays of samplers don't seem to work well with WebGL so use invididual uniforms instead
+// arrays of samplers don't seem to work well with ANGLE/DXD11 on Windows so use invididual uniforms instead
 uniform sampler2D u_csmSamplers0;
 uniform sampler2D u_csmSamplers1;
 uniform sampler2D u_csmSamplers2;
@@ -15,8 +15,6 @@ uniform sampler2D u_csmSamplers4;
 uniform sampler2D u_csmSamplers5;
 uniform sampler2D u_csmSamplers6;
 uniform sampler2D u_csmSamplers7;
-
-//uniform sampler2D u_csmSamplers[numCSM];
 uniform vec2 u_csmPCFClip[numCSM];
 varying vec3 v_csmUVs[numCSM];
 
@@ -67,32 +65,6 @@ float getShadow()
 			#if numCSM > 7
 			if(i == 7) return getCSMShadow(u_csmSamplers7, uv, pcf);
 			#endif
-
-//			#if numCSM > 0
-//			if(i == 0) return getCSMShadow(u_csmSamplers[0], uv, pcf);
-//			#endif
-//			#if numCSM > 1
-//			if(i == 1) return getCSMShadow(u_csmSamplers[1], uv, pcf);
-//			#endif
-//			#if numCSM > 2
-//			if(i == 2) return getCSMShadow(u_csmSamplers[2], uv, pcf);
-//			#endif
-//			#if numCSM > 3
-//			if(i == 3) return getCSMShadow(u_csmSamplers[3], uv, pcf);
-//			#endif
-//			#if numCSM > 4
-//			if(i == 4) return getCSMShadow(u_csmSamplers[4], uv, pcf);
-//			#endif
-//			#if numCSM > 5
-//			if(i == 5) return getCSMShadow(u_csmSamplers[5], uv, pcf);
-//			#endif
-//			#if numCSM > 6
-//			if(i == 6) return getCSMShadow(u_csmSamplers[6], uv, pcf);
-//			#endif
-//			#if numCSM > 7
-//			if(i == 7) return getCSMShadow(u_csmSamplers[7], uv, pcf);
-//			#endif
-
 		}
 	}
 	// default map

--- a/gltf/src/net/mgsx/gltf/shaders/pbr/shadows.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/pbr/shadows.glsl
@@ -16,6 +16,7 @@ uniform sampler2D u_csmSamplers5;
 uniform sampler2D u_csmSamplers6;
 uniform sampler2D u_csmSamplers7;
 
+//uniform sampler2D u_csmSamplers[numCSM];
 uniform vec2 u_csmPCFClip[numCSM];
 varying vec3 v_csmUVs[numCSM];
 
@@ -65,7 +66,32 @@ float getShadow()
 			#endif
 			#if numCSM > 7
 			if(i == 7) return getCSMShadow(u_csmSamplers7, uv, pcf);
-			#endif			
+			#endif
+
+//			#if numCSM > 0
+//			if(i == 0) return getCSMShadow(u_csmSamplers[0], uv, pcf);
+//			#endif
+//			#if numCSM > 1
+//			if(i == 1) return getCSMShadow(u_csmSamplers[1], uv, pcf);
+//			#endif
+//			#if numCSM > 2
+//			if(i == 2) return getCSMShadow(u_csmSamplers[2], uv, pcf);
+//			#endif
+//			#if numCSM > 3
+//			if(i == 3) return getCSMShadow(u_csmSamplers[3], uv, pcf);
+//			#endif
+//			#if numCSM > 4
+//			if(i == 4) return getCSMShadow(u_csmSamplers[4], uv, pcf);
+//			#endif
+//			#if numCSM > 5
+//			if(i == 5) return getCSMShadow(u_csmSamplers[5], uv, pcf);
+//			#endif
+//			#if numCSM > 6
+//			if(i == 6) return getCSMShadow(u_csmSamplers[6], uv, pcf);
+//			#endif
+//			#if numCSM > 7
+//			if(i == 7) return getCSMShadow(u_csmSamplers[7], uv, pcf);
+//			#endif
 
 		}
 	}

--- a/gltf/src/net/mgsx/gltf/shaders/pbr/shadows.glsl
+++ b/gltf/src/net/mgsx/gltf/shaders/pbr/shadows.glsl
@@ -6,7 +6,16 @@ varying vec3 v_shadowMapUv;
 
 #ifdef numCSM
 
-uniform sampler2D u_csmSamplers[numCSM];
+// arrays of samplers don't seem to work well with WebGL so use invididual uniforms instead
+uniform sampler2D u_csmSamplers0;
+uniform sampler2D u_csmSamplers1;
+uniform sampler2D u_csmSamplers2;
+uniform sampler2D u_csmSamplers3;
+uniform sampler2D u_csmSamplers4;
+uniform sampler2D u_csmSamplers5;
+uniform sampler2D u_csmSamplers6;
+uniform sampler2D u_csmSamplers7;
+
 uniform vec2 u_csmPCFClip[numCSM];
 varying vec3 v_csmUVs[numCSM];
 
@@ -34,28 +43,28 @@ float getShadow()
 			uv.z >= 0.0 && uv.z <= 1.0){
 			
 			#if numCSM > 0
-			if(i == 0) return getCSMShadow(u_csmSamplers[0], uv, pcf);
+			if(i == 0) return getCSMShadow(u_csmSamplers0, uv, pcf);
 			#endif
 			#if numCSM > 1
-			if(i == 1) return getCSMShadow(u_csmSamplers[1], uv, pcf);
+			if(i == 1) return getCSMShadow(u_csmSamplers1, uv, pcf);
 			#endif
 			#if numCSM > 2
-			if(i == 2) return getCSMShadow(u_csmSamplers[2], uv, pcf);
+			if(i == 2) return getCSMShadow(u_csmSamplers2, uv, pcf);
 			#endif
 			#if numCSM > 3
-			if(i == 3) return getCSMShadow(u_csmSamplers[3], uv, pcf);
+			if(i == 3) return getCSMShadow(u_csmSamplers3, uv, pcf);
 			#endif
 			#if numCSM > 4
-			if(i == 4) return getCSMShadow(u_csmSamplers[4], uv, pcf);
+			if(i == 4) return getCSMShadow(u_csmSamplers4, uv, pcf);
 			#endif
 			#if numCSM > 5
-			if(i == 5) return getCSMShadow(u_csmSamplers[5], uv, pcf);
+			if(i == 5) return getCSMShadow(u_csmSamplers5, uv, pcf);
 			#endif
 			#if numCSM > 6
-			if(i == 6) return getCSMShadow(u_csmSamplers[6], uv, pcf);
+			if(i == 6) return getCSMShadow(u_csmSamplers6, uv, pcf);
 			#endif
 			#if numCSM > 7
-			if(i == 7) return getCSMShadow(u_csmSamplers[7], uv, pcf);
+			if(i == 7) return getCSMShadow(u_csmSamplers7, uv, pcf);
 			#endif			
 
 		}


### PR DESCRIPTION
This is linked to issue #126 to fix cascaded shadow maps for the web platforms (HTML/GWT and TeaVM).

Changing the way array uniforms are handled (i.e. without integer arithmetic) helps in supporting WebGL.
Uniform array of sampler2d was replaced by separate uniforms.