### PR TITLE
Fix CSM shader binding

### DIFF
--- a/demo/desktop/build.gradle
+++ b/demo/desktop/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'application'
 
 dependencies {
     api project(":demo:core")
-    implementation "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
 }
     

--- a/demo/desktop/src/net/mgsx/gltf/demo/DesktopLauncher.java
+++ b/demo/desktop/src/net/mgsx/gltf/demo/DesktopLauncher.java
@@ -1,26 +1,23 @@
 package net.mgsx.gltf.demo;
 
 import com.badlogic.gdx.Graphics.DisplayMode;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 
 import net.mgsx.gltf.demo.ui.GLTFDemoUI;
 
 public class DesktopLauncher {
 	public static void main (String[] arg) {
 		
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		DisplayMode display = LwjglApplicationConfiguration.getDesktopDisplayMode();
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		DisplayMode display = Lwjgl3ApplicationConfiguration.getDisplayMode();
 		if(display.height >= 1440){
-			config.width = 1920;
-			config.height = 1080;
+			config.setWindowedMode(1920, 1080);
 			GLTFDemo.defaultUIScale = 2;
 		}else{
-			config.width = 1024;
-			config.height = 768;
+			config.setWindowedMode(1024, 768);
 			GLTFDemo.defaultUIScale = 1;
 		}
-		config.useHDPI = true;
 		
 		GLTFDemo.AUTOLOAD_ENTRY = arg.length > 1 ? arg[1] : null;
 		GLTFDemo.AUTOLOAD_VARIANT = arg.length > 2 ? arg[2] : null;
@@ -28,6 +25,6 @@ public class DesktopLauncher {
 		
 		GLTFDemoUI.fileSelector = new AWTFileSelector();
 		
-		new LwjglApplication(arg.length > 0 ? new GLTFDemo(arg[0]) : new GLTFDemo(), config);
+		new Lwjgl3Application(arg.length > 0 ? new GLTFDemo(arg[0]) : new GLTFDemo(), config);
 	}
 }

--- a/demo/desktop/src/net/mgsx/gltf/demo/ExempleLauncher.java
+++ b/demo/desktop/src/net/mgsx/gltf/demo/ExempleLauncher.java
@@ -1,13 +1,13 @@
 package net.mgsx.gltf.demo;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 
 import net.mgsx.gltf.examples.GLTFExample;
 
 public class ExempleLauncher {
 	public static void main (String[] arg) {
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		new LwjglApplication(new GLTFExample(), config);
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		new Lwjgl3Application(new GLTFExample(), config);
 	}
 }

--- a/demo/desktop/src/net/mgsx/gltf/demo/PostProcessingExampleLauncher.java
+++ b/demo/desktop/src/net/mgsx/gltf/demo/PostProcessingExampleLauncher.java
@@ -1,13 +1,13 @@
 package net.mgsx.gltf.demo;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 
 import net.mgsx.gltf.examples.GLTFPostProcessingExample;
 
 public class PostProcessingExampleLauncher {
 	public static void main (String[] arg) {
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		new LwjglApplication(new GLTFPostProcessingExample(), config);
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		new Lwjgl3Application(new GLTFPostProcessingExample(), config);
 	}
 }

--- a/demo/desktop/src/net/mgsx/gltf/demo/QuickStartExample.java
+++ b/demo/desktop/src/net/mgsx/gltf/demo/QuickStartExample.java
@@ -1,13 +1,13 @@
 package net.mgsx.gltf.demo;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 
 import net.mgsx.gltf.examples.GLTFQuickStartExample;
 
 public class QuickStartExample {
 	public static void main (String[] arg) {
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		new LwjglApplication(new GLTFQuickStartExample(), config);
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		new Lwjgl3Application(new GLTFQuickStartExample(), config);
 	}
 }

--- a/demo/desktop/src/net/mgsx/gltf/demo/ShaderGen.java
+++ b/demo/desktop/src/net/mgsx/gltf/demo/ShaderGen.java
@@ -1,13 +1,13 @@
 package net.mgsx.gltf.demo;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.backends.lwjgl.LwjglFiles;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
 
 import net.mgsx.gltf.scene3d.utils.ShaderParser;
 
 public class ShaderGen {
 	public static void main(String[] args) {
-		Gdx.files = new LwjglFiles();
+		Gdx.files = new Lwjgl3Files();
 		String vs = ShaderParser.parse(Gdx.files.classpath("net/mgsx/gltf/shaders/pbr/pbr.vs.glsl"));
 		Gdx.files.local("pbr-all.vs.glsl").writeString(vs, false);
 		String fs = ShaderParser.parse(Gdx.files.classpath("net/mgsx/gltf/shaders/pbr/pbr.fs.glsl"));

--- a/demo/desktop/test/net/mgsx/gltf/demo/DesktopBatchTestLauncher.java
+++ b/demo/desktop/test/net/mgsx/gltf/demo/DesktopBatchTestLauncher.java
@@ -1,9 +1,7 @@
 package net.mgsx.gltf.demo;
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
-
-import net.mgsx.gltf.demo.GLTFTest;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 
 public class DesktopBatchTestLauncher {
 	public static void main (String[] arg) {
@@ -11,9 +9,8 @@ public class DesktopBatchTestLauncher {
 		// required for HTTPS requests
 		System.setProperty("https.protocols", "TLSv1,TLSv1.1,TLSv1.2");
 
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		config.width = 1024;
-		config.height = 768;
-		new LwjglApplication(arg.length > 0 ? new GLTFTest(arg[0]) : new GLTFTest(), config);
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setWindowedMode(1024, 768);
+		new Lwjgl3Application(arg.length > 0 ? new GLTFTest(arg[0]) : new GLTFTest(), config);
 	}
 }


### PR DESCRIPTION
This is an alternative to #127

before the fix : 
- was working on LWJGL2, LWJGL3 and GWT backends (with my forgiving NVidia driver)
- didn't work on LWJGL2 and GWT backends (with my integrated GPU drivers)
- didn't work for some users on GWT and TeaVM backends.

After the fix
- works now on LWJGL3 and GWT backends (with my integrated GPU drivers)
- no longer work with LWJGL2 backend

Note that i had to migrate desktop demo to LWJGL3 backend. And LWJGL2 support will be removed once merged (which is OK imho)