### PR TITLE
Fix loading GLTF with unknwon json field

### DIFF
--- a/gltf/src/net/mgsx/gltf/loaders/glb/BinaryDataFileResolver.java
+++ b/gltf/src/net/mgsx/gltf/loaders/glb/BinaryDataFileResolver.java
@@ -89,8 +89,9 @@ public class BinaryDataFileResolver implements DataFileResolver
 			}
 			i += chunkLen;
 		}
-		
-		glModel = new Json().fromJson(GLTF.class, jsonData);
+		Json json = new Json();
+		json.setIgnoreUnknownFields(true);
+		glModel = json.fromJson(GLTF.class, jsonData);
 	}
 	
 	@Override


### PR DESCRIPTION
kenney models from fantasy-town have a modified glltf json that fails to load here because json dont ingore unknwon fields.

With the ignore flag the models can now be loaded.

https://kenney.nl/assets/fantasy-town-kit

![image](https://github.com/user-attachments/assets/7ff11d43-2a41-4bed-ab25-4001eff449f2)
